### PR TITLE
fix(permissions): administration access permissions

### DIFF
--- a/src/components/Concerns/Table/index.js
+++ b/src/components/Concerns/Table/index.js
@@ -34,7 +34,9 @@ export const DataItem = ({item, column}) => {
                     src={item.icon ?? topicIconPlaceholder}
                     width={20} 
                     title={item[column.accessor]}
-                />
+                >
+                    <SVG className={styles.nameIcon} src={topicIconPlaceholder} width={20} title={item[column.accessor]} />
+                </SVG>
                 <span
                     className={styles.nameItem}
                     title={item[column.accessor]}

--- a/src/components/Concerns/Table/styles.scss
+++ b/src/components/Concerns/Table/styles.scss
@@ -60,7 +60,7 @@
                 align-items: center;
 
                 .name-icon {
-                    margin-right: 0.5em;
+                    margin-right: 0.75rem;
 
                     path,
                     rect {

--- a/src/components/NoSurvey/index.js
+++ b/src/components/NoSurvey/index.js
@@ -1,5 +1,5 @@
 import {useMemo} from 'react';
-import {Link, useParams} from 'react-router-dom';
+import {Link} from 'react-router-dom';
 import {useSelector} from 'react-redux';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
@@ -21,7 +21,6 @@ import noSurveyImage from 'assets/images/no-survey.svg';
 import styles from './styles.scss';
 
 const NoSurveys = () => {
-    useInitActiveProject();
     const surveyModalsConfig = useSurveyModals('sens');
 
     const {activeProject} = useSelector(state => state.project);
@@ -56,15 +55,15 @@ export default NoSurveys;
 
 export const withNoSurvey = WrappedComponent => {
     const WithNoSurvey = (props) => {
-        const {projectId} = useParams();
+        useInitActiveProject();
 
-        const {surveys, status} = useSelector(state => state.survey);
-        const surveyData = surveys.filter(el => el.project === +projectId);
+        const {activeProject} = useSelector(state => state.project);
+        const {status, surveys} = useSelector(state => state.survey);
 
-        if(surveyData.length){
+        if(activeProject && surveys.some(sur => sur.project === activeProject.id)) {
             return <WrappedComponent {...props} />;
         }
-        if(status!=='complete') {
+        if(status !== 'complete') {
             return <NeatLoader containerClassName={styles.loaderContainer} />;
         }
         return <NoSurveys />;

--- a/src/components/ShareSurvey/index.js
+++ b/src/components/ShareSurvey/index.js
@@ -107,6 +107,7 @@ const ShareSurvey = props => {
                             </Dropdown>
                         </div>
                         <Button 
+                            loading={unshareLoading}
                             outline 
                             className={styles.copyButton}
                             onClick={handleCopyLink}

--- a/src/components/SummaryModal/styles.scss
+++ b/src/components/SummaryModal/styles.scss
@@ -57,7 +57,8 @@
                 padding: 4px;
                 border-radius: 6px;
                 box-shadow: 0 3px 12px 0 rgba(0, 0, 0, 0.12);
-                
+                user-select: none;
+
                 .header-item {
                     border-radius: 4px;
                     display: flex;

--- a/src/components/UserNav/styles.scss
+++ b/src/components/UserNav/styles.scss
@@ -56,6 +56,7 @@
             box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.04);
             border: solid 1px var(--color-primary);
             margin-left: 0.5em;
+            user-select: none;
         }
 
         .notifications-container {

--- a/src/containers/Administration/Statements/StatementsTable/index.js
+++ b/src/containers/Administration/Statements/StatementsTable/index.js
@@ -31,6 +31,10 @@ const maxRowsOptions = [
         label: '50',
         value: 50,
     },
+    {
+        label: '100',
+        value: 100,
+    }
 ];
 
 export const DataItem = ({item, column, contextId, moduleId}) => {
@@ -64,10 +68,13 @@ const StatementsTable = props => {
     const totalStatements = useMemo(() => statements?.length, [statements]);
 
     const [page, setPage] = useState(1);
-    const [maxRows, setMaxRows] = useState(maxRowsOptions[0]);
+    const [maxRows, setMaxRows] = useState(maxRowsOptions[maxRowsOptions.length - 1]);
 
     const handlePageChange = useCallback(({currentPage}) => setPage(currentPage), []);
-    const handleMaxRowsChange = useCallback(({option}) => setMaxRows(option), []);
+    const handleMaxRowsChange = useCallback(({option}) => {
+        setPage(1);
+        setMaxRows(option);
+    }, []);
 
     const [{result: insightsResult}, loadInsights] = usePromise(Api.getInsights);
 
@@ -155,7 +162,7 @@ const StatementsTable = props => {
                         valueExtractor={labelExtractor}
                         onChange={handleMaxRowsChange}
                         value={maxRows}
-                        defaultValue={maxRowsOptions[0]}
+                        defaultValue={maxRowsOptions[maxRowsOptions.length - 1]}
                         clearable={false}
                         searchable={false}
                         optionsDirection="up"
@@ -169,7 +176,7 @@ const StatementsTable = props => {
                     onChange={handlePageChange} 
                     totalRecords={totalStatements}
                     pageNeighbours={1}
-                    pageLimit={maxRows.value} 
+                    pageLimit={maxRows.value}
                     pageNum={page}
                 />
             </div>

--- a/src/containers/Projects/Dashboard/SurveyTable/index.js
+++ b/src/containers/Projects/Dashboard/SurveyTable/index.js
@@ -134,10 +134,9 @@ const SurveyTable = ({onTakeSurveyClick}) => {
     const navigate = useNavigate();
 
     const {activeProject} = useSelector(state => state.project);
-    const {status} = useSelector(state => state.survey);
 
     const surveys = useSelector(getFormattedSurveys);
-    const surveyData = surveys.filter(el => el.project === +projectId);
+    const surveyData = useMemo(() => surveys.filter(el => el.project === +projectId), [surveys, projectId]);
 
     const hasEditAccess = useMemo(() => 
         checkEditAccess(activeProject?.accessLevel), 
@@ -165,11 +164,11 @@ const SurveyTable = ({onTakeSurveyClick}) => {
             <p className={styles.subTitle}>{surveyData.length} <Localize>surveys</Localize></p>
             <div className={styles.surveyTable}>
                 <Table 
-                    loading={status==='loading'}
+                    loading={!activeProject || (activeProject.surveysCount > 0 && !surveyData.length)}
                     LoadingComponent={<NeatLoader medium />}
                     className={styles.table} 
                     data={surveyData} 
-                    columns={surveyColumns} 
+                    columns={surveyColumns}
                     maxRows={10}
                     renderHeaderItem={HeaderItem}
                     renderDataItem={DataItem}

--- a/src/containers/Surveys/Dashboard/Module/index.js
+++ b/src/containers/Surveys/Dashboard/Module/index.js
@@ -100,7 +100,9 @@ const Module = props => {
                             src={iconSrc || topicIconPlaceholder}
                             width={20} 
                             title={title}
-                        />
+                        >
+                            <SVG className={styles.tabIcon} width={20}  src={topicIconPlaceholder} title={title} />
+                        </SVG>
                         <span className={styles.tabLabel}>{title}</span>
                     </div>
                 </Editable>

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -68,7 +68,7 @@ const AppRoutes = () => {
                     <Route path="account" element={<PrivateRoute><Account /></PrivateRoute>} />
                     <Route path="organizations" element={<PrivateRoute><Organizations /></PrivateRoute>} />
                     <Route path="administration" element={<PrivateRoute><Administration /></PrivateRoute>}>
-                        <Route path="" element={<Navigate to="/administration/statements" />} />
+                        <Route path="" element={<Navigate to="/administration/statements" replace />} />
                         <Route exact path="statements">
                             <Route path="" element={<AdministrationStatements />} />
                             <Route path=":statementId">

--- a/src/utils/permission.js
+++ b/src/utils/permission.js
@@ -15,13 +15,23 @@ export const checkEditAccess = accessLevel => {
 };
 
 export const weightagePermissions = [
-    'summary.add_optionstatement',
-    'summary.change_optionstatement',
-    'summary.delete_optionstatement',
-    'summary.add_questionstatement',
-    'summary.change_questionstatement',
-    'summary.delete_questionstatement',
-    'summary.add_statement',
-    'summary.change_statement',
-    'summary.delete_statement',
+    'statement.view_statement',
+    'statement.add_statement',
+    'statement.change_statement',
+    'statement.delete_statement',
+
+    'statement.view_questionstatement',
+    'statement.add_questionstatement',
+    'statement.change_questionstatement',
+    'statement.delete_questionstatement',
+
+    'statement.view_optionstatement',
+    'statement.add_optionstatement',
+    'statement.change_optionstatement',
+    'statement.delete_optionstatement',
+
+    'statement.view_statementformula',
+    'statement.add_statementformula',
+    'statement.change_statementformula',
+    'statement.delete_statementformula',
 ];


### PR DESCRIPTION
Fix administration access permissions.
Add fallback statement topic icon in case of network failure during fetch.
Fix loader showing multiple times in survey table.
Fix go back not working when navigating to administration.
Add 100 rows as default value in administration statements table.